### PR TITLE
FM6126 init procedure embeded into lib

### DIFF
--- a/ESP32-RGB64x32MatrixPanel-I2S-DMA.cpp
+++ b/ESP32-RGB64x32MatrixPanel-I2S-DMA.cpp
@@ -778,3 +778,106 @@ void RGB64x32MatrixPanel_I2S_DMA::updateMatrixDMABuffer(uint8_t red, uint8_t gre
   } // end row iteration
 
 } // updateMatrixDMABuffer (full frame paint)
+
+/**
+ * pre-init procedures for specific drivers
+ * 
+ */
+void RGB64x32MatrixPanel_I2S_DMA::shiftDriver(const shift_driver _drv, const int dma_r1_pin, const int dma_g1_pin, const int dma_b1_pin, const int dma_r2_pin, const int dma_g2_pin, const int dma_b2_pin, const int dma_a_pin, const int dma_b_pin, const int dma_c_pin, const int dma_d_pin, const int dma_e_pin, const int dma_lat_pin, const int dma_oe_pin, const int dma_clk_pin){
+    switch (_drv){
+    case FM6124:
+    case FM6126A:
+    {
+      #if SERIAL_DEBUG 
+        Serial.println( F("RGB64x32MatrixPanel_I2S_DMA - initializing FM6124 driver..."));
+      #endif
+      int C12[16] = {0, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1};
+      int C13[16] = {0, 0, 0, 0, 0, 0, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0};
+
+      pinMode(dma_r1_pin, OUTPUT);
+      pinMode(dma_g1_pin, OUTPUT);
+      pinMode(dma_b1_pin, OUTPUT);
+      pinMode(dma_r2_pin, OUTPUT);
+      pinMode(dma_g2_pin, OUTPUT);
+      pinMode(dma_b2_pin, OUTPUT);
+      pinMode(dma_a_pin, OUTPUT);
+      pinMode(dma_b_pin, OUTPUT);
+      pinMode(dma_c_pin, OUTPUT);
+      pinMode(dma_d_pin, OUTPUT);
+      pinMode(dma_e_pin, OUTPUT);
+      pinMode(dma_clk_pin, OUTPUT);
+      pinMode(dma_lat_pin, OUTPUT);
+      pinMode(dma_oe_pin, OUTPUT);
+
+      // Send Data to control register 11
+      digitalWrite(dma_oe_pin, HIGH); // Display reset
+      digitalWrite(dma_lat_pin, LOW);
+      digitalWrite(dma_clk_pin, LOW);
+      for (int l = 0; l < MATRIX_WIDTH; l++){
+          int y = l % 16;
+          digitalWrite(dma_r1_pin, LOW);
+          digitalWrite(dma_g1_pin, LOW);
+          digitalWrite(dma_b1_pin, LOW);
+          digitalWrite(dma_r2_pin, LOW);
+          digitalWrite(dma_g2_pin, LOW);
+          digitalWrite(dma_b2_pin, LOW);
+
+          if (C12[y] == 1){
+              digitalWrite(dma_r1_pin, HIGH);
+              digitalWrite(dma_g1_pin, HIGH);
+              digitalWrite(dma_b1_pin, HIGH);
+              digitalWrite(dma_r2_pin, HIGH);
+              digitalWrite(dma_g2_pin, HIGH);
+              digitalWrite(dma_b2_pin, HIGH);
+          }
+
+          if (l > MATRIX_WIDTH - 12){
+              digitalWrite(dma_lat_pin, HIGH);
+          } else {
+              digitalWrite(dma_lat_pin, LOW);
+          }
+
+          digitalWrite(dma_clk_pin, HIGH);
+          digitalWrite(dma_clk_pin, LOW);
+      }
+
+      digitalWrite(dma_lat_pin, LOW);
+      digitalWrite(dma_clk_pin, LOW);
+
+      // Send Data to control register 12
+      for (int l = 0; l < MATRIX_WIDTH; l++){
+          int y = l % 16;
+          digitalWrite(dma_r1_pin, LOW);
+          digitalWrite(dma_g1_pin, LOW);
+          digitalWrite(dma_b1_pin, LOW);
+          digitalWrite(dma_r2_pin, LOW);
+          digitalWrite(dma_g2_pin, LOW);
+          digitalWrite(dma_b2_pin, LOW);
+
+          if (C13[y] == 1){
+              digitalWrite(dma_r1_pin, HIGH);
+              digitalWrite(dma_g1_pin, HIGH);
+              digitalWrite(dma_b1_pin, HIGH);
+              digitalWrite(dma_r2_pin, HIGH);
+              digitalWrite(dma_g2_pin, HIGH);
+              digitalWrite(dma_b2_pin, HIGH);
+          }
+
+          if (l > MATRIX_WIDTH - 13){
+              digitalWrite(dma_lat_pin, HIGH);
+          } else {
+              digitalWrite(dma_lat_pin, LOW);
+          }
+          digitalWrite(dma_clk_pin, HIGH);
+          digitalWrite(dma_clk_pin, LOW);
+      }
+
+      digitalWrite(dma_lat_pin, LOW);
+      digitalWrite(dma_clk_pin, LOW);
+      break;
+    }
+    case SHIFT:
+    default:
+      break;
+    }
+}

--- a/ESP32-RGB64x32MatrixPanel-I2S-DMA.h
+++ b/ESP32-RGB64x32MatrixPanel-I2S-DMA.h
@@ -24,13 +24,21 @@
  * All of this is memory permitting of course (dependant on your sketch etc.) ...
  *
  */
-#define MATRIX_WIDTH                64   // CHANGE THIS VALUE IF CHAINING
-#define MATRIX_HEIGHT               32   // CHANGE THIS VALUE ONLY IF USING 64px HIGH panel with E PIN
+#ifndef MATRIX_WIDTH
+ #define MATRIX_WIDTH                64   // CHANGE THIS VALUE IF CHAINING
+#endif
 
+#ifndef MATRIX_HEIGHT
+ #define MATRIX_HEIGHT               32   // CHANGE THIS VALUE ONLY IF USING 64px HIGH panel with E PIN
+#endif
 
 /* Best to keep these values as is. */
-#define PIXEL_COLOR_DEPTH_BITS      8   // 8bit per RGB color = 24 bit/per pixel, reduce to save RAM
-#define MATRIX_ROWS_IN_PARALLEL     2   // Don't change this unless you know what you're doing
+#ifndef PIXEL_COLOR_DEPTH_BITS
+ #define PIXEL_COLOR_DEPTH_BITS      8   // 8bit per RGB color = 24 bit/per pixel, reduce to save RAM
+#endif
+#ifndef MATRIX_ROWS_IN_PARALLEL
+ #define MATRIX_ROWS_IN_PARALLEL     2   // Don't change this unless you know what you're doing
+#endif
 
 /* ESP32 Default Pin definition. You can change this, but best if you keep it as is and provide custom pin mappings 
  * as part of the begin(...) function.
@@ -151,6 +159,7 @@ typedef struct RGB24 {
     uint8_t blue;
 } RGB24;
 
+enum shift_driver {SHIFT=0, FM6124, FM6126A};
 
 /***************************************************************************************/   
 // Used by val2PWM
@@ -185,7 +194,7 @@ class RGB64x32MatrixPanel_I2S_DMA : public Adafruit_GFX {
     }
 
     /* Propagate the DMA pin configuration, or use compiler defaults */
-    bool begin(int dma_r1_pin = R1_PIN_DEFAULT , int dma_g1_pin = G1_PIN_DEFAULT, int dma_b1_pin = B1_PIN_DEFAULT , int dma_r2_pin = R2_PIN_DEFAULT , int dma_g2_pin = G2_PIN_DEFAULT , int dma_b2_pin = B2_PIN_DEFAULT , int dma_a_pin  = A_PIN_DEFAULT  , int dma_b_pin = B_PIN_DEFAULT  , int dma_c_pin = C_PIN_DEFAULT , int dma_d_pin = D_PIN_DEFAULT  , int dma_e_pin = E_PIN_DEFAULT , int dma_lat_pin = LAT_PIN_DEFAULT, int dma_oe_pin = OE_PIN_DEFAULT , int dma_clk_pin = CLK_PIN_DEFAULT)
+    bool begin(int dma_r1_pin = R1_PIN_DEFAULT , int dma_g1_pin = G1_PIN_DEFAULT, int dma_b1_pin = B1_PIN_DEFAULT , int dma_r2_pin = R2_PIN_DEFAULT , int dma_g2_pin = G2_PIN_DEFAULT , int dma_b2_pin = B2_PIN_DEFAULT , int dma_a_pin  = A_PIN_DEFAULT  , int dma_b_pin = B_PIN_DEFAULT  , int dma_c_pin = C_PIN_DEFAULT , int dma_d_pin = D_PIN_DEFAULT  , int dma_e_pin = E_PIN_DEFAULT , int dma_lat_pin = LAT_PIN_DEFAULT, int dma_oe_pin = OE_PIN_DEFAULT , int dma_clk_pin = CLK_PIN_DEFAULT, const shift_driver _drv=SHIFT)
     {
 
       // Change 'if' to '1' to enable, 0 to not include this Serial output in compiled program        
@@ -205,6 +214,10 @@ class RGB64x32MatrixPanel_I2S_DMA : public Adafruit_GFX {
             Serial.printf("Using pin %d for the OE_PIN\n",  dma_oe_pin);    
             Serial.printf("Using pin %d for the CLK_PIN\n", dma_clk_pin); 
       #endif   
+
+      // initialize some sppecific panel drivers
+      if (_drv)
+        shiftDriver(_drv, dma_r1_pin, dma_g1_pin, dma_b1_pin, dma_r2_pin, dma_g2_pin, dma_b2_pin, dma_a_pin, dma_b_pin, dma_c_pin, dma_d_pin, dma_e_pin, dma_lat_pin, dma_oe_pin, dma_clk_pin);
 
      /* As DMA buffers are dynamically allocated, we must allocated in begin()
       * Ref: https://github.com/espressif/arduino-esp32/issues/831
@@ -296,8 +309,7 @@ class RGB64x32MatrixPanel_I2S_DMA : public Adafruit_GFX {
     } 
 
   int  calculated_refresh_rate  = 0;         
-            
-    
+
    // ------- PRIVATE -------
   private:
 
@@ -331,6 +343,12 @@ class RGB64x32MatrixPanel_I2S_DMA : public Adafruit_GFX {
    
     /* Update the entire DMA buffer (aka. The RGB Panel) a certain colour (wipe the screen basically) */
     void updateMatrixDMABuffer(uint8_t red, uint8_t green, uint8_t blue);       
+
+    /**
+     * pre-init procedures for specific drivers
+     * 
+     */
+    void shiftDriver(const shift_driver _drv, const int dma_r1_pin, const int dma_g1_pin, const int dma_b1_pin, const int dma_r2_pin, const int dma_g2_pin, const int dma_b2_pin, const int dma_a_pin, const int dma_b_pin, const int dma_c_pin, const int dma_d_pin, const int dma_e_pin, const int dma_lat_pin, const int dma_oe_pin, const int dma_clk_pin);
 
 }; // end Class header
 

--- a/examples/FM6126Panel/FM6126Panel.ino
+++ b/examples/FM6126Panel/FM6126Panel.ino
@@ -4,153 +4,93 @@
 #include <Arduino.h>
 #include <ESP32-RGB64x32MatrixPanel-I2S-DMA.h>
 
-RGB64x32MatrixPanel_I2S_DMA matrix;
+RGB64x32MatrixPanel_I2S_DMA dma_display;
+
+#include <FastLED.h>
 
 ////////////////////////////////////////////////////////////////////
 // Reset Panel
-// This needs to be near the top of the code
-//
-// Change these to whatever suits
-// recommended settings and patches are by
+// FM6126 support is still experimental
 //
 // pinout for ESP38 38pin module
 // http://arduinoinfo.mywikis.net/wiki/Esp32#KS0413_keyestudio_ESP32_Core_Board
 //
 
+// HUB75E pinout
 // R1 | G1
 // B1 | GND
 // R2 | G2
 // B2 | E
-// A | B
-// C | D
+//  A | B
+//  C | D
 // CLK| LAT
 // OE | GND
 
 #define R1 25
 #define G1 26
 #define BL1 27
-#define R2 5 // 21 SDA
-#define G2 19 // 22 SDL
-#define BL2 23
-#define CH_A 12
-#define CH_B 16
-#define CH_C 17
-#define CH_D 18
-#define CH_E -1 // assign to pin if using two panels
-#define CLK 15
-#define LAT 32
-#define OE 33
+#define R2 14 // 21 SDA
+#define G2 12 // 22 SDL
+#define BL2 13
+#define CH_A 23
+#define CH_B 19
+#define CH_C 5
+#define CH_D 17
+#define CH_E 32 // assign to any available pin if using two panels or 64x64 panels with 1/32 scan
+#define CLK 16
+#define LAT 4
+#define OE 15
 
-void resetPanel()
-{
-int MaxLed = 64;
-
-int C12[16] = {0, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1};
-int C13[16] = {0, 0, 0, 0, 0, 0, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0};
-
-pinMode(R1, OUTPUT);
-pinMode(G1, OUTPUT);
-pinMode(BL1, OUTPUT);
-pinMode(R2, OUTPUT);
-pinMode(G2, OUTPUT);
-pinMode(BL2, OUTPUT);
-pinMode(CH_A, OUTPUT);
-pinMode(CH_B, OUTPUT);
-pinMode(CH_C, OUTPUT);
-pinMode(CH_D, OUTPUT);
-pinMode(CH_E, OUTPUT);
-pinMode(CLK, OUTPUT);
-pinMode(LAT, OUTPUT);
-pinMode(OE, OUTPUT);
-
-// Send Data to control register 11
-digitalWrite(OE, HIGH); // Display reset
-digitalWrite(LAT, LOW);
-digitalWrite(CLK, LOW);
-for (int l = 0; l < MaxLed; l++)
-{
-int y = l % 16;
-digitalWrite(R1, LOW);
-digitalWrite(G1, LOW);
-digitalWrite(BL1, LOW);
-digitalWrite(R2, LOW);
-digitalWrite(G2, LOW);
-digitalWrite(BL2, LOW);
-if (C12[y] == 1)
-{
-digitalWrite(R1, HIGH);
-digitalWrite(G1, HIGH);
-digitalWrite(BL1, HIGH);
-digitalWrite(R2, HIGH);
-digitalWrite(G2, HIGH);
-digitalWrite(BL2, HIGH);
-}
-if (l > MaxLed - 12)
-{
-digitalWrite(LAT, HIGH);
-}
-else
-{
-digitalWrite(LAT, LOW);
-}
-digitalWrite(CLK, HIGH);
-digitalWrite(CLK, LOW);
-}
-digitalWrite(LAT, LOW);
-digitalWrite(CLK, LOW);
-// Send Data to control register 12
-for (int l = 0; l < MaxLed; l++)
-{
-int y = l % 16;
-digitalWrite(R1, LOW);
-digitalWrite(G1, LOW);
-digitalWrite(BL1, LOW);
-digitalWrite(R2, LOW);
-digitalWrite(G2, LOW);
-digitalWrite(BL2, LOW);
-if (C13[y] == 1)
-{
-digitalWrite(R1, HIGH);
-digitalWrite(G1, HIGH);
-digitalWrite(BL1, HIGH);
-digitalWrite(R2, HIGH);
-digitalWrite(G2, HIGH);
-digitalWrite(BL2, HIGH);
-}
-if (l > MaxLed - 13)
-{
-digitalWrite(LAT, HIGH);
-}
-else
-{
-digitalWrite(LAT, LOW);
-}
-digitalWrite(CLK, HIGH);
-digitalWrite(CLK, LOW);
-}
-digitalWrite(LAT, LOW);
-digitalWrite(CLK, LOW);
-}
 // End of default setup for RGB Matrix 64x32 panel
 ///////////////////////////////////////////////////////////////
 
+int time_counter = 0;
+int cycles = 0;
+
+CRGB currentColor;
+CRGBPalette16 palettes[] = {HeatColors_p, LavaColors_p, RainbowColors_p, RainbowStripeColors_p, CloudColors_p};
+CRGBPalette16 currentPalette = palettes[0];
+
+
+CRGB ColorFromCurrentPalette(uint8_t index = 0, uint8_t brightness = 255, TBlendType blendType = LINEARBLEND) {
+  return ColorFromPalette(currentPalette, index, brightness, blendType);
+}
+
 void setup(){
 
-resetPanel(); // do this before matrix.begin
+    // If you experience ghosting, you will need to reduce the brightness level, not all RGB Matrix
+    // Panels are the same - some seem to display ghosting artefacts at lower brightness levels.
+    // In the setup() function do something like:
 
-// If you experience ghosting, you will need to reduce the brightness level, not all RGB Matrix
-// Panels are the same - some seem to display ghosting artefacts at lower brightness levels.
-// In the setup() function do something like:
+    dma_display.setPanelBrightness(30); // SETS THE BRIGHTNESS HERE. 60 OR LOWER IDEAL.
 
-matrix.setPanelBrightness(10); // SETS THE BRIGHTNESS HERE. 60 OR LOWER IDEAL.
-
-matrix.begin(R1, G1, BL1, R2, G2, BL2, CH_A, CH_B, CH_C, CH_D, CH_E, LAT, OE, CLK); // setup the LED matrix
-matrix.setTextColor(matrix.Color(96, 0, 96)); // r,g,b
-matrix.setCursor(1, 15);
-matrix.println("Hello World");
-
+    /**
+     * be sure to specify 'FM6126A' as last parametr to the begin(),
+     * it would reset 6126 registers and enables the matrix
+     */
+    dma_display.begin(R1, G1, BL1, R2, G2, BL2, CH_A, CH_B, CH_C, CH_D, CH_E, LAT, OE, CLK, FM6126A);
 }
 
 void loop(){
+   for (int x = 0; x <  dma_display.width(); x++) {
+        for (int y = 0; y <  dma_display.height(); y++) {
+            int16_t v = 0;
+            uint8_t wibble = sin8(time_counter);
+            v += sin16(x * wibble * 3 + time_counter);
+            v += cos16(y * (128 - wibble)  + time_counter);
+            v += sin16(y * x * cos8(-time_counter) / 8);
 
+            currentColor = ColorFromPalette(currentPalette, (v >> 8) + 127); //, brightness, currentBlendType);
+            dma_display.drawPixelRGB888(x, y, currentColor.r, currentColor.g, currentColor.b);
+        }
+    }
+
+    time_counter += 1;
+    cycles++;
+
+    if (cycles >= 1024) {
+        time_counter = 0;
+        cycles = 0;
+        currentPalette = palettes[random(0,sizeof(palettes))];
+    }
 }


### PR DESCRIPTION
looks like reset ption for FM6126 from example works pretty fine. Was able to drive two 64x64 matrixes without any issues, looks awesome!
So decided to embed this reset method within the lib so not to copy/paste in into every sketch. API has not changed, just added optional parameter with shifter type to the begin().
  - example updated
  - allow MATRIX params to be defined outside the lib during compilation time

thanks for you work, great lib!